### PR TITLE
Slog

### DIFF
--- a/slog/logs_proper.json
+++ b/slog/logs_proper.json
@@ -1,0 +1,2 @@
+{"time":"2025-09-19T00:24:16.826591+03:00","level":"INFO","msg":"There will be information","user":"111"}
+{"time":"2025-09-19T00:24:16.8345146+03:00","level":"WARN","msg":"This is a Warning!","code":123}

--- a/slog/main.go
+++ b/slog/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+type CompositeHandler struct {
+	handlers []slog.Handler
+}
+
+func NewCompositeHandler(handlers ...slog.Handler) *CompositeHandler {
+	return &CompositeHandler{handlers: handlers}
+}
+
+func (c *CompositeHandler) Enabled(_ context.Context, level slog.Level) bool {
+	fmt.Println("CompositeHandler.Enabled called")
+	return true
+}
+
+func (c *CompositeHandler) Handle(ctx context.Context, record slog.Record) error {
+	fmt.Println("CompositeHandler.Handle called:", record.Message)
+	for _, h := range c.handlers {
+		if err := h.Handle(ctx, record); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *CompositeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return c
+}
+
+func (c *CompositeHandler) WithGroup(name string) slog.Handler {
+	return c
+}
+
+func main() {
+	textHandler := slog.NewTextHandler(os.Stdout, nil)
+	file, _ := os.Create("logs_proper.json")
+	defer file.Close()
+	jsonHandler := slog.NewJSONHandler(file, nil)
+
+	composite := NewCompositeHandler(textHandler, jsonHandler)
+
+	logger := slog.New(composite)
+
+	logger.Info("There will be information", slog.String("user", "111"))
+	logger.Warn("This is a Warning!", slog.Int("code", 123))
+}


### PR DESCRIPTION
### Description
## Ticket reference

### В пакете slog существует интерфейс Handler для конфигурации обработки логов.
Вам необходимо создать структуру CompositeHandler которая позволяет обрабатывать логи сразу в нескольких Handler. CompositHandler содержит под собой []slog.Handler, при вызове методов y CompositeHandler, соответствующие методы должны вызываться у каждого хендлера из слайса. Для проверки работоспособности CompositeHandler, необходимо создать Logger с помощью CompositeHandler. При логгировании события через данный логгер, логи должны выводиться в терминал пользователя в текстовом формате и в файл в формате json. Для этого испльзуйте стандарные реализации реализации интерфейса Handler - JSONHandler TextHandler.

Implemented CompositeHandler for slog that forwards log events to multiple handlers simultaneously. Combined TextHandler (terminal output) and JSONHandler (file output). Demonstrated logging Info and Warn messages with additional attributes.